### PR TITLE
allow digits in the hearthpwn card names. This should fix golden card…

### DIFF
--- a/import/import-heartpwn-cards.js
+++ b/import/import-heartpwn-cards.js
@@ -53,7 +53,7 @@
   index.setSettings(settings);
 
   var numberPattern = /\/([0-9]*)-/;
-  var idPattern = /[0-9]*-([-a-z]*)/;
+  var idPattern = /[0-9]*-(.*)/;
 
   console.log('Start scrap');
 


### PR DESCRIPTION
…s for cards with a number inside:

Blingtron 3000
SI:7 Agent
Gorillabot A-3
Arcane Nullifier X-21
Foe Reaper 4000